### PR TITLE
Improvement to 4x20 LCD display

### DIFF
--- a/h1/NanoEls.ino
+++ b/h1/NanoEls.ino
@@ -271,7 +271,7 @@ void updateDisplay() {
       case LCD_VAL_ANGLE:       
          lcd.setCursor(7,3);
          lcd.print(round(((spindlePos % (int) ENCODER_STEPS + (int) ENCODER_STEPS) % (int) ENCODER_STEPS) * 360 / ENCODER_STEPS));
-         lcd.print("deg ");
+         lcd.print("deg  ");
          displayStep = LCD_VAL_ON_OFF;
          break;
           

--- a/h1/README.md
+++ b/h1/README.md
@@ -1,0 +1,3 @@
+# NanoEls by kachurovskiy
+## Improvements
+### Removed flicker/blurred text on the 4x20 LCD.

--- a/h1/README.md
+++ b/h1/README.md
@@ -1,3 +1,3 @@
 # NanoEls by kachurovskiy
 ## Improvements
-### Removed flicker/blurred text on the 4x20 LCD.
+Removed flicker/blurred text on the 4x20 LCD.


### PR DESCRIPTION
Many people have noticed that the 4x20 LCD display flickers and produces washed out, blurred text when values are changing quickly. This change significantly improves display quality by removing the flicker, though fast changing value are still a little blurry simply due to the slow update speed of these displays.  

The cause of the flicker this the lcd.clear() command which is being issued on every loop iteration, so the entire display is cleared and then re-drawn.  With the slow update speed of the LCD this results in flicker. The clear command is quite slow (~1.5ms) so removing this also benefits LCD update execution time.  This time is further reduced by using a simple state machine to update only one parameter per loop iteration.

The state machine approach has not been applied to the OLED code (since I don't have one to test) but would be simple to do so and would decrease the execution time.